### PR TITLE
FIX: SASS Partials' Statements, Imports & Warnings

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.21.0",
+				"@types/node": "^24.6.2",
 				"@types/react": "^19.0.10",
 				"@types/react-dom": "^19.0.4",
 				"@vitejs/plugin-react": "^4.3.4",
@@ -1750,6 +1751,16 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "24.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+			"integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.13.0"
+			}
 		},
 		"node_modules/@types/react": {
 			"version": "19.1.1",
@@ -3620,6 +3631,13 @@
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <5.9.0"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+			"integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.3",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.21.0",
+		"@types/node": "^24.6.2",
 		"@types/react": "^19.0.10",
 		"@types/react-dom": "^19.0.4",
 		"@vitejs/plugin-react": "^4.3.4",

--- a/client/package.json
+++ b/client/package.json
@@ -4,11 +4,11 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
+		"dev": "SASS_QUIET_DEPRECATIONS=1 vite",
 		"build": "vite build",
 		"lint": "eslint .",
 		"preview": "vite preview",
-		"local": "vite -- --host"
+		"local": "SASS_QUIET_DEPRECATIONS=1 vite -- --host"
 	},
 	"dependencies": {
 		"@reduxjs/toolkit": "^2.6.1",

--- a/client/src/css/achievements/AchievementBadge.module.scss
+++ b/client/src/css/achievements/AchievementBadge.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AchievementBadge {
 	width: 2.5rem;
 	height: 2.5rem;

--- a/client/src/css/achievements/AchievementMedal.module.scss
+++ b/client/src/css/achievements/AchievementMedal.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AchievementMedal {
 	width: 2.5rem;
 	height: 2.5rem;

--- a/client/src/css/achievements/AchievementStreak.module.scss
+++ b/client/src/css/achievements/AchievementStreak.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AchievementStreak {
 	$baseSize: 2rem;
 	width: $size;

--- a/client/src/css/active-workout/ActiveWorkout.module.scss
+++ b/client/src/css/active-workout/ActiveWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ActiveWorkout {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/active-workout/AddWorkoutDetails.module.scss
+++ b/client/src/css/active-workout/AddWorkoutDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StepHeader {
 	width: 100%;
 	text-align: center;

--- a/client/src/css/active-workout/EndedWorkout.module.scss
+++ b/client/src/css/active-workout/EndedWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .EndedWorkout {
 	width: 100%;
 	@include colCenter();

--- a/client/src/css/active-workout/WorkoutTimer.module.scss
+++ b/client/src/css/active-workout/WorkoutTimer.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WorkoutTimer {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/activity/TypeBadge.module.scss
+++ b/client/src/css/activity/TypeBadge.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $size: 4rem;
 $icon: calc($size - 30%);
 

--- a/client/src/css/calendars/DateRangeCalendar.module.scss
+++ b/client/src/css/calendars/DateRangeCalendar.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DateRangeCalendar {
 	width: 100%;
 	height: 100%;
@@ -94,8 +90,6 @@
 	color: $text1;
 }
 
-// $radius: 2.5rem;
-// $radius: 1rem;
 $radius: 5rem;
 
 .isStart {

--- a/client/src/css/dashboard/DailyCaloriesForWeek.module.scss
+++ b/client/src/css/dashboard/DailyCaloriesForWeek.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DailyCaloriesForWeek {
 	width: 100%;
 	padding: 0.5rem;

--- a/client/src/css/dashboard/DailyMinsForWeek.module.scss
+++ b/client/src/css/dashboard/DailyMinsForWeek.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DailyMinsForWeek {
 	width: 100%;
 	padding: 0.5rem;

--- a/client/src/css/dashboard/DailyStepsForWeek.module.scss
+++ b/client/src/css/dashboard/DailyStepsForWeek.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DailyStepsForWeek {
 	width: 100%;
 	padding: 0.5rem;

--- a/client/src/css/dashboard/DashboardHabits.module.scss
+++ b/client/src/css/dashboard/DashboardHabits.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DashboardHabits {
 	width: 100%;
 	margin: 1rem 0;

--- a/client/src/css/dashboard/DashboardSectionTabs.module.scss
+++ b/client/src/css/dashboard/DashboardSectionTabs.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DashboardSectionTabs {
 	width: 100%;
 	height: auto;

--- a/client/src/css/dashboard/RecentHistoryTabs.module.scss
+++ b/client/src/css/dashboard/RecentHistoryTabs.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RecentHistoryTabs {
 	width: 100%;
 }

--- a/client/src/css/details/CardioDetails.module.scss
+++ b/client/src/css/details/CardioDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CardioDetails {
 	width: 100%;
 

--- a/client/src/css/details/DetailsBlock.module.scss
+++ b/client/src/css/details/DetailsBlock.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DetailsBlock {
 	width: 15rem;
 	height: auto;

--- a/client/src/css/details/HistoryDetails.module.scss
+++ b/client/src/css/details/HistoryDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HistoryDetails {
 	width: 100%;
 	margin: 2rem 0;

--- a/client/src/css/details/OtherDetails.module.scss
+++ b/client/src/css/details/OtherDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .OtherDetails {
 	width: 100%;
 

--- a/client/src/css/details/PostWorkoutDetails.module.scss
+++ b/client/src/css/details/PostWorkoutDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .PostWorkoutDetails {
 	width: 100%;
 	@include colCenter();

--- a/client/src/css/details/ScheduleDetails.module.scss
+++ b/client/src/css/details/ScheduleDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ScheduleDetails {
 	width: 100%;
 	padding: 0 1rem;

--- a/client/src/css/details/StrengthDetails.module.scss
+++ b/client/src/css/details/StrengthDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StrengthDetails {
 	width: 100%;
 

--- a/client/src/css/details/StretchDetails.module.scss
+++ b/client/src/css/details/StretchDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StretchDetails {
 	width: 100%;
 

--- a/client/src/css/details/TimedDetails.module.scss
+++ b/client/src/css/details/TimedDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TimedDetails {
 	width: 100%;
 

--- a/client/src/css/details/ViewPostWorkout.module.scss
+++ b/client/src/css/details/ViewPostWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ViewPostWorkout {
 	width: 100%;
 

--- a/client/src/css/details/ViewSessionDetails.module.scss
+++ b/client/src/css/details/ViewSessionDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ViewSessionDetails {
 	width: 100%;
 	height: auto;

--- a/client/src/css/details/WalkDetails.module.scss
+++ b/client/src/css/details/WalkDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WalkDetails {
 	width: 100%;
 

--- a/client/src/css/form/EditStrengthSets.module.scss
+++ b/client/src/css/form/EditStrengthSets.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .EditStrengthSets {
 	width: 100%;
 	padding: 1rem 3rem;

--- a/client/src/css/form/EditWalkInfo.module.scss
+++ b/client/src/css/form/EditWalkInfo.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .EditWalkInfo {
 	width: 100%;
 	height: auto;

--- a/client/src/css/form/EditWorkoutSets.module.scss
+++ b/client/src/css/form/EditWorkoutSets.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .EditWorkoutSets {
 	width: 100%;
 	padding: 1rem 3rem;

--- a/client/src/css/form/RecurringOptions.module.scss
+++ b/client/src/css/form/RecurringOptions.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RecurringOptions {
 	width: 100%;
 

--- a/client/src/css/habits/ChangeHabitGoal.module.scss
+++ b/client/src/css/habits/ChangeHabitGoal.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ChangeHabitGoal {
 	width: 100%;
 	padding: 0 3rem;

--- a/client/src/css/habits/CreateHabit.module.scss
+++ b/client/src/css/habits/CreateHabit.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StepHeader {
 	width: 100%;
 	text-align: center;

--- a/client/src/css/habits/DeleteHabit.module.scss
+++ b/client/src/css/habits/DeleteHabit.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DeleteHabit {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/habits/HabitCard.module.scss
+++ b/client/src/css/habits/HabitCard.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitCard {
 	width: 25rem;
 	height: 15rem;

--- a/client/src/css/habits/HabitDay.module.scss
+++ b/client/src/css/habits/HabitDay.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $radius: 1rem;
 
 .HabitDay {

--- a/client/src/css/habits/HabitHistory.module.scss
+++ b/client/src/css/habits/HabitHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitHistory {
 	@include fill_container;
 	max-height: 93%;

--- a/client/src/css/habits/HabitHistoryCalendar.module.scss
+++ b/client/src/css/habits/HabitHistoryCalendar.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitHistoryCalendar {
 	width: 100%;
 }

--- a/client/src/css/habits/HabitHistoryDateDetails.module.scss
+++ b/client/src/css/habits/HabitHistoryDateDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitHistoryDateDetails {
 	width: 100%;
 	margin-top: 2rem;

--- a/client/src/css/habits/HabitHistoryModal.module.scss
+++ b/client/src/css/habits/HabitHistoryModal.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitHistoryModal {
 	@include fill_container;
 	padding: 1rem 2rem;

--- a/client/src/css/habits/HabitLogger.module.scss
+++ b/client/src/css/habits/HabitLogger.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $display: 8rem;
 $displayWidth: 14rem;
 

--- a/client/src/css/habits/HabitMonth.module.scss
+++ b/client/src/css/habits/HabitMonth.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitMonth {
 	width: 100%;
 	height: auto;

--- a/client/src/css/habits/HabitTracker.module.scss
+++ b/client/src/css/habits/HabitTracker.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitTracker {
 	width: 100%;
 	// height: 100dvh;

--- a/client/src/css/habits/HabitsList.module.scss
+++ b/client/src/css/habits/HabitsList.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitsList {
 	width: 100%;
 	padding-left: 1rem;

--- a/client/src/css/habits/QuickLogHabit.module.scss
+++ b/client/src/css/habits/QuickLogHabit.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $display: 8rem;
 $displayWidth: 14rem;
 

--- a/client/src/css/habits/RecentHabitLogs.module.scss
+++ b/client/src/css/habits/RecentHabitLogs.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RecentHabitLogs {
 	width: 100%;
 

--- a/client/src/css/history/AllHistoryEntry.module.scss
+++ b/client/src/css/history/AllHistoryEntry.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AllHistoryEntry {
 	@include historyStyles();
 	background-color: var(--todayStyles);

--- a/client/src/css/history/CardioHistoryEntry.module.scss
+++ b/client/src/css/history/CardioHistoryEntry.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CardioHistoryEntry {
 	width: max-content;
 	margin-left: auto;

--- a/client/src/css/history/HistoryEntry.module.scss
+++ b/client/src/css/history/HistoryEntry.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HistoryEntry {
 	@include historyStyles();
 	background-color: var(--todayStyles);

--- a/client/src/css/history/HistoryTabs.module.scss
+++ b/client/src/css/history/HistoryTabs.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HistoryTabs {
 	width: 100%;
 	height: auto;

--- a/client/src/css/history/LogWorkout.module.scss
+++ b/client/src/css/history/LogWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StepHeader {
 	width: 100%;
 	text-align: center;

--- a/client/src/css/history/StrengthHistoryEntry.module.scss
+++ b/client/src/css/history/StrengthHistoryEntry.module.scss
@@ -1,11 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WeightBadge {
 	$color: var(--blueGrey700);
 	width: max-content;

--- a/client/src/css/history/WalkHistoryEntry.module.scss
+++ b/client/src/css/history/WalkHistoryEntry.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WalkHistoryEntry {
 	width: max-content;
 	margin-left: auto;

--- a/client/src/css/layout/Card.module.scss
+++ b/client/src/css/layout/Card.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .Card {
 	@include cardBase();
 	padding: 1rem;

--- a/client/src/css/layout/CardsCarousel.module.scss
+++ b/client/src/css/layout/CardsCarousel.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CardsCarousel {
 	position: relative;
 	width: 100%;

--- a/client/src/css/layout/CardsSection.module.scss
+++ b/client/src/css/layout/CardsSection.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CardsSection {
 	width: 100%;
 	height: auto;

--- a/client/src/css/layout/DashboardLayout.module.scss
+++ b/client/src/css/layout/DashboardLayout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AppLayout {
 	width: 100%;
 	height: auto;

--- a/client/src/css/layout/DetailsCard.module.scss
+++ b/client/src/css/layout/DetailsCard.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DetailsCard {
 	@include fill_container;
 

--- a/client/src/css/layout/Loader.module.scss
+++ b/client/src/css/layout/Loader.module.scss
@@ -1,13 +1,11 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
+@use "@sass/variables" as *;
 
 $size: 48px;
 
 .Loader {
 	width: 100%;
 	height: auto;
-	@include colCenter;
+	@include colCenter();
 
 	&_inner {
 		width: max-content;

--- a/client/src/css/layout/NavArrows.module.scss
+++ b/client/src/css/layout/NavArrows.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 @mixin navBtn() {
 	width: max-content;
 	height: 3rem;

--- a/client/src/css/layout/Navbar.module.scss
+++ b/client/src/css/layout/Navbar.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .Navbar {
 	position: fixed;
 	display: block;

--- a/client/src/css/layout/PageContainer.module.scss
+++ b/client/src/css/layout/PageContainer.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .PageContainer {
 	width: 100%;
 	height: auto;

--- a/client/src/css/layout/PageHeader.module.scss
+++ b/client/src/css/layout/PageHeader.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .PageHeader {
 	width: 100%;
 	height: 12rem;

--- a/client/src/css/layout/PageTabs.module.scss
+++ b/client/src/css/layout/PageTabs.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .PageTabs {
 	width: max-content;
 	height: auto;

--- a/client/src/css/layout/SectionAccordion.module.scss
+++ b/client/src/css/layout/SectionAccordion.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .SectionAccordion {
 	width: 100%;
 	padding: 1rem 0;

--- a/client/src/css/layout/TopNav.module.scss
+++ b/client/src/css/layout/TopNav.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TopNav {
 	width: 100%;
 	height: auto;

--- a/client/src/css/layout/WeeklyHeader.module.scss
+++ b/client/src/css/layout/WeeklyHeader.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WeeklyHeader {
 	width: 100%;
 

--- a/client/src/css/login/CreateAccountForm.module.scss
+++ b/client/src/css/login/CreateAccountForm.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CreateAccountForm {
 	width: 100%;
 	height: 40rem;

--- a/client/src/css/login/LoginForm.module.scss
+++ b/client/src/css/login/LoginForm.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .LoginForm {
 	width: 100%;
 	height: 40rem;

--- a/client/src/css/medications/CreateMedSchedule.module.scss
+++ b/client/src/css/medications/CreateMedSchedule.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CreateMedSchedule {
 	width: 100%;
 	padding: 1rem 2rem;

--- a/client/src/css/medications/LogMedication.module.scss
+++ b/client/src/css/medications/LogMedication.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .LogMedication {
 	width: 100%;
 	min-height: auto;

--- a/client/src/css/medications/LoggedMedsCard.module.scss
+++ b/client/src/css/medications/LoggedMedsCard.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .LoggedMedsCard {
 	width: 100%;
 

--- a/client/src/css/medications/MedicationLogHistory.module.scss
+++ b/client/src/css/medications/MedicationLogHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MedicationLogHistory {
 	width: 100%;
 	display: block;

--- a/client/src/css/medications/MedicationsList.module.scss
+++ b/client/src/css/medications/MedicationsList.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MedicationsList {
 	width: 100%;
 }

--- a/client/src/css/medications/PillSummary.module.scss
+++ b/client/src/css/medications/PillSummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .PillSummary {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/medications/TodaysDoses.module.scss
+++ b/client/src/css/medications/TodaysDoses.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TodaysDoses {
 	width: 100%;
 

--- a/client/src/css/pages/ActiveWorkoutPage.module.scss
+++ b/client/src/css/pages/ActiveWorkoutPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ActiveWorkoutPage {
 	width: 100%;
 

--- a/client/src/css/pages/AllWorkoutsPage.module.scss
+++ b/client/src/css/pages/AllWorkoutsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AllWorkoutsPage {
 	width: 100%;
 

--- a/client/src/css/pages/CreateAccountPage.module.scss
+++ b/client/src/css/pages/CreateAccountPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CreateAccountPage {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/pages/DashboardPage.module.scss
+++ b/client/src/css/pages/DashboardPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .DashboardPage {
 	width: 100%;
 

--- a/client/src/css/pages/GoalsPage.module.scss
+++ b/client/src/css/pages/GoalsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .GoalsPage {
 	width: 100%;
 

--- a/client/src/css/pages/HabitHistoryPage.module.scss
+++ b/client/src/css/pages/HabitHistoryPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitHistoryPage {
 	width: 100%;
 

--- a/client/src/css/pages/HabitsPage.module.scss
+++ b/client/src/css/pages/HabitsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitsPage {
 	width: 100%;
 

--- a/client/src/css/pages/HistoryPage.module.scss
+++ b/client/src/css/pages/HistoryPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HistoryPage {
 	width: 100%;
 

--- a/client/src/css/pages/LoginPage.module.scss
+++ b/client/src/css/pages/LoginPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .LoginPage {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/pages/MedicationDetailsPage.module.scss
+++ b/client/src/css/pages/MedicationDetailsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MedicationDetailsPage {
 	width: 100%;
 

--- a/client/src/css/pages/MedicationsPage.module.scss
+++ b/client/src/css/pages/MedicationsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MedicationsPage {
 	width: 100%;
 

--- a/client/src/css/pages/NotFoundPage.module.scss
+++ b/client/src/css/pages/NotFoundPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .NotFoundPage {
 	@include fill_container;
 	@include colCenter();

--- a/client/src/css/pages/RecentActivityPage.module.scss
+++ b/client/src/css/pages/RecentActivityPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RecentActivityPage {
 	width: 100%;
 	height: auto;

--- a/client/src/css/pages/RecentHabitHistoryPage.module.scss
+++ b/client/src/css/pages/RecentHabitHistoryPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RecentHabitHistoryPage {
 	width: 100%;
 

--- a/client/src/css/pages/SettingsPage.module.scss
+++ b/client/src/css/pages/SettingsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .SettingsPage {
 	width: 100%;
 

--- a/client/src/css/pages/StatsPage.module.scss
+++ b/client/src/css/pages/StatsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StatsPage {
 	width: 100%;
 	font-size: 3rem;

--- a/client/src/css/pages/TrendsPage.module.scss
+++ b/client/src/css/pages/TrendsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TrendsPage {
 	width: 100%;
 

--- a/client/src/css/pages/WorkoutsPage.module.scss
+++ b/client/src/css/pages/WorkoutsPage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WorkoutsPage {
 	@include fill_container;
 

--- a/client/src/css/recent-activity/ActivitySegments.module.scss
+++ b/client/src/css/recent-activity/ActivitySegments.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ActivitySegments {
 	width: 100%;
 	display: block;

--- a/client/src/css/recent-activity/NoSegments.module.scss
+++ b/client/src/css/recent-activity/NoSegments.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .NoSegments {
 	width: 100%;
 

--- a/client/src/css/recent-activity/RangeSelector.module.scss
+++ b/client/src/css/recent-activity/RangeSelector.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RangeSelector {
 	width: 100%;
 	height: 3.5rem;

--- a/client/src/css/recent-activity/RecentActivityBreakdown.module.scss
+++ b/client/src/css/recent-activity/RecentActivityBreakdown.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RecentActivityBreakdown {
 	width: 100%;
 

--- a/client/src/css/recent-activity/RingBreakdown.module.scss
+++ b/client/src/css/recent-activity/RingBreakdown.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RingBreakdown {
 	width: 100%;
 	height: auto;

--- a/client/src/css/recent-activity/SegmentBreakdown.module.scss
+++ b/client/src/css/recent-activity/SegmentBreakdown.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .SegmentBreakdown {
 	width: 100%;
 	padding: 1rem 0;

--- a/client/src/css/shared/CounterInput.module.scss
+++ b/client/src/css/shared/CounterInput.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 @mixin counterBtn() {
 	width: 3.5rem;
 	height: 3.5rem;

--- a/client/src/css/shared/CustomCheckbox.module.scss
+++ b/client/src/css/shared/CustomCheckbox.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CustomCheckbox {
 	width: max-content;
 	height: max-content;

--- a/client/src/css/shared/DatePicker.module.scss
+++ b/client/src/css/shared/DatePicker.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $titleSize: 1.8rem;
 $navSize: 3rem;
 

--- a/client/src/css/shared/MenuDropdown.module.scss
+++ b/client/src/css/shared/MenuDropdown.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MenuDropdown {
 	position: absolute;
 	display: block;

--- a/client/src/css/shared/MinutesSelector.module.scss
+++ b/client/src/css/shared/MinutesSelector.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MinutesSelector {
 	width: 100%;
 	margin-bottom: 1.5rem;

--- a/client/src/css/shared/ModalLG.module.scss
+++ b/client/src/css/shared/ModalLG.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ModalLG {
 	@include modalLG();
 	box-shadow: -4px 5px 100px -19px rgba(0, 0, 0, 1);

--- a/client/src/css/shared/ModalSM.module.scss
+++ b/client/src/css/shared/ModalSM.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ModalSM {
 	@include modal();
 	box-shadow: -4px 5px 100px -19px rgba(0, 0, 0, 1);

--- a/client/src/css/shared/ModalWithFooter.module.scss
+++ b/client/src/css/shared/ModalWithFooter.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ModalWithFooter {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/shared/MonthPicker.module.scss
+++ b/client/src/css/shared/MonthPicker.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $titleSize: 1.8rem;
 $navSize: 3rem;
 

--- a/client/src/css/shared/MultiStepModal.module.scss
+++ b/client/src/css/shared/MultiStepModal.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MultiStepModal {
 	position: fixed;
 	display: block;

--- a/client/src/css/shared/NumberInput.module.scss
+++ b/client/src/css/shared/NumberInput.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .NumberInput {
 	min-width: 5rem;
 	width: max-content;

--- a/client/src/css/shared/PasswordInput.module.scss
+++ b/client/src/css/shared/PasswordInput.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .PasswordInput {
 	position: relative;
 	width: 100%;

--- a/client/src/css/shared/QuarterPicker.module.scss
+++ b/client/src/css/shared/QuarterPicker.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $titleSize: 1.8rem;
 $navSize: 3rem;
 

--- a/client/src/css/shared/Select.module.scss
+++ b/client/src/css/shared/Select.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .Select {
 	width: 15rem;
 	border-radius: 0.5rem;

--- a/client/src/css/shared/TextArea.module.scss
+++ b/client/src/css/shared/TextArea.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TextArea {
 	width: 100%;
 	height: auto;

--- a/client/src/css/shared/TextInput.module.scss
+++ b/client/src/css/shared/TextInput.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TextInput {
 	width: 100%;
 	height: auto;

--- a/client/src/css/shared/TimePicker.module.scss
+++ b/client/src/css/shared/TimePicker.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TimePicker {
 	width: max-content;
 	height: auto;

--- a/client/src/css/shared/TimerInput.module.scss
+++ b/client/src/css/shared/TimerInput.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TimerInput {
 	width: auto;
 	@include flex_row(flex-start, center);

--- a/client/src/css/shared/YearPicker.module.scss
+++ b/client/src/css/shared/YearPicker.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $titleSize: 1.8rem;
 $navSize: 3rem;
 

--- a/client/src/css/summary/CaloriesSummary.module.scss
+++ b/client/src/css/summary/CaloriesSummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CaloriesSummary {
 	width: 100%;
 	height: auto;

--- a/client/src/css/summary/HabitSummary.module.scss
+++ b/client/src/css/summary/HabitSummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .HabitSummary {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/summary/MinutesSummary.module.scss
+++ b/client/src/css/summary/MinutesSummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MinutesSummary {
 	width: 100%;
 	min-width: 100%;

--- a/client/src/css/summary/StatsSummary.module.scss
+++ b/client/src/css/summary/StatsSummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StatsSummary {
 	width: 100%;
 	padding: 0.5rem;

--- a/client/src/css/summary/StepsSummary.module.scss
+++ b/client/src/css/summary/StepsSummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StepsSummary {
 	width: 100%;
 	min-width: 100%;

--- a/client/src/css/summary/WorkoutHistoryCalendar.module.scss
+++ b/client/src/css/summary/WorkoutHistoryCalendar.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WorkoutHistoryCalendar {
 	width: 100%;
 	margin-top: 4rem;

--- a/client/src/css/summary/WorkoutHistoryCalendarDay.module.scss
+++ b/client/src/css/summary/WorkoutHistoryCalendarDay.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $radius: 1rem;
 
 .WorkoutHistoryCalendarDay {

--- a/client/src/css/summary/WorkoutHistoryCalendarDetails.module.scss
+++ b/client/src/css/summary/WorkoutHistoryCalendarDetails.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WorkoutHistoryCalendarDetails {
 	width: 100%;
 	margin-top: 3rem;

--- a/client/src/css/summary/YearlySummary.module.scss
+++ b/client/src/css/summary/YearlySummary.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .YearlySummary {
 	width: 100%;
 	padding: 0.5rem;

--- a/client/src/css/ui/CustomImage.module.scss
+++ b/client/src/css/ui/CustomImage.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .Image {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/ui/FadeIn.module.scss
+++ b/client/src/css/ui/FadeIn.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .FadeIn {
 	width: auto;
 	height: auto;

--- a/client/src/css/ui/FadeSlideIn.module.scss
+++ b/client/src/css/ui/FadeSlideIn.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .FadeSlideIn {
 	position: relative;
 	width: auto;

--- a/client/src/css/ui/InfoBanner.module.scss
+++ b/client/src/css/ui/InfoBanner.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .InfoBanner {
 	width: 100%;
 	padding: 1rem 1.5rem;

--- a/client/src/css/ui/Marquee.module.scss
+++ b/client/src/css/ui/Marquee.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .Marquee {
 	width: 100%;
 	overflow: hidden;

--- a/client/src/css/ui/NoData.module.scss
+++ b/client/src/css/ui/NoData.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .NoData {
 	width: 100%;
 	height: 7rem;

--- a/client/src/css/ui/NumberCounter.module.scss
+++ b/client/src/css/ui/NumberCounter.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .NumberCounter {
 	width: 15ch;
 	font-variant-numeric: tabular-nums;

--- a/client/src/css/ui/ProgressBar.module.scss
+++ b/client/src/css/ui/ProgressBar.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ProgressBar {
 	width: 100%;
 	min-width: 15rem;

--- a/client/src/css/ui/ProgressCircle.module.scss
+++ b/client/src/css/ui/ProgressCircle.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ProgressCircle {
 	@include fill_container;
 	@include rowCenter;

--- a/client/src/css/ui/RingSegments.module.scss
+++ b/client/src/css/ui/RingSegments.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .RingSegments {
 	width: 100%;
 	height: auto;

--- a/client/src/css/ui/SlideInDirection.module.scss
+++ b/client/src/css/ui/SlideInDirection.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .SlideInDirection {
 	width: auto;
 	height: auto;

--- a/client/src/css/ui/SlideInStaggeredList.module.scss
+++ b/client/src/css/ui/SlideInStaggeredList.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .SlideInStaggeredList {
 	width: auto;
 	height: auto;

--- a/client/src/css/ui/TimeCounter.module.scss
+++ b/client/src/css/ui/TimeCounter.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TimeCounter {
 	width: 15ch;
 	font-variant-numeric: tabular-nums;

--- a/client/src/css/user/UserBadge.module.scss
+++ b/client/src/css/user/UserBadge.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 $badgeSize: 7.8rem;
 
 @mixin badge($size: 7.8rem) {

--- a/client/src/css/views/AllHistory.module.scss
+++ b/client/src/css/views/AllHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AllHistory {
 	width: 100%;
 

--- a/client/src/css/views/CardioHistory.module.scss
+++ b/client/src/css/views/CardioHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .CardioHistory {
 	width: 100%;
 

--- a/client/src/css/views/OtherHistory.module.scss
+++ b/client/src/css/views/OtherHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .OtherHistory {
 	width: 100%;
 

--- a/client/src/css/views/StrengthHistory.module.scss
+++ b/client/src/css/views/StrengthHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StrengthHistory {
 	width: 100%;
 

--- a/client/src/css/views/StretchHistory.module.scss
+++ b/client/src/css/views/StretchHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .StretchHistory {
 	width: 100%;
 

--- a/client/src/css/views/TimedHistory.module.scss
+++ b/client/src/css/views/TimedHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TimedHistory {
 	width: 100%;
 

--- a/client/src/css/views/WalkHistory.module.scss
+++ b/client/src/css/views/WalkHistory.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .WalkHistory {
 	width: 100%;
 

--- a/client/src/css/workouts/AllWorkouts.module.scss
+++ b/client/src/css/workouts/AllWorkouts.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .AllWorkouts {
 	width: 100%;
 	margin-top: 4rem;

--- a/client/src/css/workouts/CreateWorkout.module.scss
+++ b/client/src/css/workouts/CreateWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 %stepStyles {
 	min-height: 100%;
 }

--- a/client/src/css/workouts/MarkAsDone.module.scss
+++ b/client/src/css/workouts/MarkAsDone.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .MarkAsDone {
 	position: relative;
 	width: 100%;

--- a/client/src/css/workouts/SkipWorkout.module.scss
+++ b/client/src/css/workouts/SkipWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .SkipWorkout {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/workouts/TodaysWorkout.module.scss
+++ b/client/src/css/workouts/TodaysWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TodaysWorkout {
 	width: 100%;
 	min-width: 100%;

--- a/client/src/css/workouts/TodaysWorkouts.module.scss
+++ b/client/src/css/workouts/TodaysWorkouts.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .TodaysWorkouts {
 	width: 100%;
 	padding: 3rem 0;

--- a/client/src/css/workouts/UnskipWorkout.module.scss
+++ b/client/src/css/workouts/UnskipWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .UnskipWorkout {
 	width: 100%;
 	height: 100%;

--- a/client/src/css/workouts/ViewWorkout.module.scss
+++ b/client/src/css/workouts/ViewWorkout.module.scss
@@ -1,7 +1,3 @@
-@use "../../sass/variables" as *;
-@use "../../sass/mixins" as *;
-@use "../../sass/custom" as *;
-
 .ViewWorkout {
 	width: 100%;
 	height: auto;

--- a/client/src/sass/_custom.scss
+++ b/client/src/sass/_custom.scss
@@ -1,3 +1,5 @@
+@use "@sass/variables" as *;
+
 @mixin fill_container {
 	width: 100%;
 	height: 100%;

--- a/client/src/sass/_mixins.scss
+++ b/client/src/sass/_mixins.scss
@@ -1,3 +1,6 @@
+@use "@sass/variables" as *;
+@use "@sass/custom" as *;
+
 @mixin scrollbar($color: var(--blueGrey400)) {
 	&::-webkit-scrollbar {
 		display: inline;
@@ -105,7 +108,6 @@ $modalRadius: 5rem;
 	bottom: 0;
 	left: 0;
 	transform: translate(-50%, -0%);
-
 	width: 100dvw;
 	height: 90dvh;
 	border-radius: $modalRadius $modalRadius 0 0;

--- a/client/src/sass/_mixins.scss
+++ b/client/src/sass/_mixins.scss
@@ -141,6 +141,7 @@ $modalRadius: 5rem;
 		gap: 0 0.5rem;
 		margin-bottom: 1.5rem;
 		font-size: 1.8rem;
+
 		&_month {
 			font-weight: 700;
 			color: $text1;
@@ -155,13 +156,15 @@ $modalRadius: 5rem;
 		width: 100%;
 		@include flex_row(space-evenly, center);
 		gap: 0 1rem;
+	}
 
-		&_day {
-			font-size: 1.5rem;
-			color: $text2;
-		}
+	&_weekdays_day {
+		// flatten nested rule to avoid mixed declarations
+		font-size: 1.5rem;
+		color: $text2;
 	}
 }
+
 @mixin calendarBody() {
 	@include fill_container;
 	min-height: 40rem;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -7,5 +8,21 @@ export default defineConfig({
 	server: {
 		host: true,
 		port: 5175,
+	},
+	resolve: {
+		alias: {
+			"@sass": path.resolve(__dirname, "src/sass"),
+		},
+	},
+	css: {
+		preprocessorOptions: {
+			scss: {
+				additionalData: `
+          @use "@sass/variables" as *;
+          @use "@sass/mixins" as *;
+          @use "@sass/custom" as *;
+        `,
+			},
+		},
 	},
 });

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -18,10 +18,11 @@ export default defineConfig({
 		preprocessorOptions: {
 			scss: {
 				additionalData: `
-          @use "@sass/variables" as *;
-          @use "@sass/mixins" as *;
-          @use "@sass/custom" as *;
+				@use "@sass/variables" as *;
+				@use "@sass/mixins" as *;
+				@use "@sass/custom" as *;
         `,
+				quietDeps: true,
 			},
 		},
 	},


### PR DESCRIPTION
In modern SASS (eg Dart Sass), the syntax for importing partials has changed: 
From (old): `@import '/path/to/partial.scss';`
To (new): `@use '/path/to/partial.scss' as *;`
- I performed a find & replace on all import partials to use the new modern syntax
- Then I updated the vite.config.ts file to inject the modern syntax into all files automatically.

So, now there are no longer any manual or explicit import states EXCEPT in the partial files themselves. This is to prevent scoping issue and some partials depend on other partials. But scss modules do not require this and can be injected at runtime.
